### PR TITLE
Make package options fully configurable 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ __pycache__/
 build/
 dist/
 
+# IDE files
+.idea/

--- a/jhub_remote_user_authenticator/remote_user_auth.py
+++ b/jhub_remote_user_authenticator/remote_user_auth.py
@@ -9,36 +9,65 @@ from traitlets import Unicode
 
 
 class RemoteUserLoginHandler(BaseHandler):
+    """Attempt user login using data from incoming request header"""
 
     def get(self):
-        remote_user = self.request.headers.get("Cn", "").lower()
-        remote_roles = self.request.headers.get("isMemberOf", "")
+
+        # Check for username in header information
+        header_name = self.authenticator.header_name
+        remote_user = self.request.headers.get(header_name, "").lower()
         if remote_user == "":
             raise web.HTTPError(401)
 
-        user = self.user_from_username(remote_user)
-        home_dir_exists = os.path.exists(os.path.expanduser('~{}'.format(remote_user)))
-
-        if (not home_dir_exists) and remote_roles == "SAM-SSLVPNSAMUsers":
-            self.redirect("https://crc.pitt.edu/node/1042")
-
-        elif remote_roles == "SAM-SSLVPNSAMUsers":
-            self.set_login_cookie(user)
-            self.redirect(url_path_join(self.hub.server.base_url, 'home'))
-
-        else:
+        # Check for necessary VPN role using request headers
+        header_vpn = self.authenticator.header_vpn
+        remote_roles = self.request.headers.get(header_vpn, "")
+        required_vpn_role = self.authenticator.required_vpn_role
+        if required_vpn_role != remote_roles:
             self.redirect("https://crc.pitt.edu/node/1041")
 
+        # Require the user has an existing home directory
+        user = self.user_from_username(remote_user)
+        home_dir_exists = os.path.exists(os.path.expanduser('~{}'.format(remote_user)))
+        if not home_dir_exists:
+            self.redirect("https://crc.pitt.edu/node/1042")
 
-class RemoteUserAuthenticator(Authenticator):
-    """
-    Accept the authenticated user name from the REMOTE_USER HTTP header.
-    """
+        # Facilitate user authentication
+        self.set_login_cookie(user)
+        self.redirect(url_path_join(self.hub.server.base_url, 'home'))
+
+
+class AuthenticatorSettings:
+    """Defines common, configurable settings for user authenticators."""
 
     header_name = Unicode(
-        default_value='REMOTE_USER',
+        default_value='Cn',
         config=True,
         help="""HTTP header to inspect for the authenticated username.""")
+
+    header_vpn = Unicode(
+        default_value='isMemberOf',
+        config=True,
+        help="""HTTP header to inspect for user VPN role(s).""")
+
+    required_vpn_role = Unicode(
+        default_value='SAM-SSLVPNSAMUsers',
+        config=True,
+        help="""Required VPN role for accessing the service.""")
+
+    user_redirect = Unicode(
+        default_value='https://crc.pitt.edu/node/1042',
+        config=True,
+        help="""Url to redirect to if user has no home directory.""")
+
+    vpn_redirect = Unicode(
+        default_value='https://crc.pitt.edu/node/1041',
+        config=True,
+        help="""Url to redirect to if user is missing necessary VPN role.""")
+
+
+class RemoteUserAuthenticator(AuthenticatorSettings, Authenticator):
+    """Accept the authenticated user name from the REMOTE_USER HTTP header."""
 
     def get_handlers(self, app):
         return [
@@ -50,17 +79,12 @@ class RemoteUserAuthenticator(Authenticator):
         raise NotImplementedError()
 
 
-class RemoteUserLocalAuthenticator(LocalAuthenticator):
+class RemoteUserLocalAuthenticator(AuthenticatorSettings, LocalAuthenticator):
     """
     Accept the authenticated user name from the REMOTE_USER HTTP header.
     Derived from LocalAuthenticator for use of features such as adding
     local accounts through the admin interface.
     """
-
-    header_name = Unicode(
-        default_value='REMOTE_USER',
-        config=True,
-        help="""HTTP header to inspect for the authenticated username.""")
 
     def get_handlers(self, app):
         return [

--- a/jhub_remote_user_authenticator/remote_user_auth.py
+++ b/jhub_remote_user_authenticator/remote_user_auth.py
@@ -12,7 +12,6 @@ class RemoteUserLoginHandler(BaseHandler):
     """Attempt user login using data from incoming request header"""
 
     def get(self):
-
         # Check for username in header information
         header_name = self.authenticator.header_name
         remote_user = self.request.headers.get(header_name, "").lower()
@@ -28,8 +27,8 @@ class RemoteUserLoginHandler(BaseHandler):
 
         # Require the user has an existing home directory
         user = self.user_from_username(remote_user)
-        home_dir_exists = os.path.exists(os.path.expanduser('~{}'.format(remote_user)))
-        if not home_dir_exists:
+        user_home_dir = os.path.expanduser('~{}'.format(remote_user))
+        if not os.path.exists(user_home_dir):
             self.redirect("https://crc.pitt.edu/node/1042")
 
         # Facilitate user authentication


### PR DESCRIPTION
I've refactored the authenticator to use values from the Jupyter config file instead of hardcoded settings. Default values are chosen to reflect existing values (this ensures backward compatibility).

I've used an equality when checking for a valid VPN role, since that is how the code was originally written (line 3 below):

```python
remote_roles = self.request.headers.get(header_vpn, "")
required_vpn_role = self.authenticator.required_vpn_role
if required_vpn_role != remote_roles:  # Note the usage of !=
    ...
```
This might be a naive question, but can anyone in @pitt-crc/pitt-it carify how VPN roles are defined in the HTTP headers? Specifically, is it always a single value or can there be multiple roles defined in some format? I'd like to understand how the values are specified so I can understand how/why the current authenticator logic works. 

For context, see issue #7.

